### PR TITLE
IllegalStateException was thrown at: org.jetbrains.kotlin.codegen.inline.InlineCodegen$Companion.getCompiledMethodNodeInner(InlineCodegen.kt:596)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,33 @@ plugins {
     id 'kotlin-android'
 }
 
+def android_builder_version = "4.0.1"
+
+ext {
+    android_builder_main_version = Integer.parseInt(android_builder_version.split("\\.")[0])
+    android_builder_mid_version = Integer.parseInt(android_builder_version.split("\\.")[1])
+}
+
 android {
+    this.rootProject.buildscript.configurations.classpath
+            .resolvedConfiguration
+            .firstLevelModuleDependencies.
+            each {
+                def name = it.name
+                if (name.contains('com.android.tools.build:gradle')) {
+                    def moduleVersion = it.moduleVersion
+                    if (moduleVersion.contains("-")) {
+                        def versionArray = moduleVersion.split("-")
+                        ext.android_builder_main_version = Integer.parseInt(versionArray[0])
+                        ext.android_builder_mid_version = Integer.parseInt(versionArray[1])
+                    } else {
+                        version = moduleVersion
+                        android_builder_version = moduleVersion
+                        ext.android_builder_main_version = Integer.parseInt(android_builder_version.split("\\.")[0])
+                        ext.android_builder_mid_version = Integer.parseInt(android_builder_version.split("\\.")[1])
+                    }
+                }
+            }
     compileSdkVersion 30
 
     defaultConfig {
@@ -40,9 +66,13 @@ android {
         jvmTarget = "1.8"
     }
 
-    buildFeatures {
-        compose true
+    if (ext.android_builder_main_version >= 7 || (ext.android_builder_main_version > 4 && ext.android_builder_mid_version > 1)) {
+        buildFeatures {
+            compose true
+        }
+    }
 
+    buildFeatures {
         // Disable unused AGP features
         buildConfig false
         aidl false
@@ -64,18 +94,60 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.3.2'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.3.0'
-    implementation "androidx.activity:activity-compose:1.3.0-alpha03"
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.material:material:$compose_version"
-    implementation "androidx.compose.material:material-icons-extended:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling:$compose_version"
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.0'
-
     testImplementation 'junit:junit:4.13.2'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
+
+    implementation 'androidx.core:core-ktx:1.3.2'
+    implementation 'com.google.android.material:material:1.3.0'
+    if (android_builder_main_version < 7) {
+        add("kotlinCompilerPluginClasspath", "androidx.compose.compiler:compiler:$compose_version")
+    }
+    implementation "androidx.appcompat:appcompat:$compose_appcompat_version"
+    implementation "androidx.activity:activity-compose:$compose_activity_version"
+    // ...compiler and runtime from previous code snippet
+    implementation "androidx.compose.runtime:runtime:$compose_version"
+    implementation "androidx.compose.runtime:runtime-saveable:$compose_version"
+    implementation "androidx.compose.runtime:runtime-livedata:$compose_version"
+
+    implementation "androidx.compose.ui:ui:$compose_version"
+    implementation "androidx.compose.ui:ui-text:$compose_version"
+    implementation "androidx.compose.ui:ui-geometry:$compose_version"
+    implementation "androidx.compose.ui:ui-graphics:$compose_version"
+    // Tooling support (Previews, etc.)
+    implementation "androidx.compose.ui:ui-tooling:$compose_version"
+    implementation "androidx.compose.ui:ui-util:$compose_version"
+    implementation "androidx.compose.ui:ui-unit:$compose_version"
+    // Animation
+    implementation "androidx.compose.animation:animation:$compose_version"
+    implementation "androidx.compose.animation:animation-core:$compose_version"
+    // Navigation
+    implementation "androidx.navigation:navigation-compose:$compose_navigation_version"
+    // Foundation (Border, Background, Box, Image, Scroll, shapes, animations, etc.)
+    implementation "androidx.compose.foundation:foundation:$compose_version"
+    implementation "androidx.compose.foundation:foundation-layout:$compose_version"
+    // Material Design
+    implementation "androidx.compose.material:material:$compose_version"
+    // Material design icons
+    implementation "androidx.compose.material:material-icons-core:$compose_version"
+    implementation "androidx.compose.material:material-icons-extended:$compose_version"
+    implementation "androidx.compose.material:material-ripple:$compose_version"
+
+    implementation "androidx.compose.ui:ui-viewbinding:$compose_version"
+
+    // Constraintlayout
+    implementation "androidx.constraintlayout:constraintlayout-compose:$compose_constraintlayout_version"
+    // Integration with activities
+    implementation "androidx.activity:activity-compose:$compose_activity_version"
+    // Integration with ViewModels
+    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$compose_lifecycle_version"
+
+    //accompanist  -- Utils for Jetpack Compose
+    implementation "com.google.accompanist:accompanist-coil:$compose_accompanist"
+
+    implementation "androidx.compose.runtime:runtime-livedata:$compose_version"
+
+
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,11 +16,19 @@
 
 buildscript {
    ext{
+       android_gradle_plugin_version = '4.0.1'
        kotlin_version = '1.4.32'
 
        coroutines_version = '1.4.2'
 
-       compose_version = '1.0.0-beta01'
+       compose_activity_version = '1.3.0-alpha07'   // 1.3.0-alpha04 1.3.0-alpha05 1.3.0-alpha07
+       compose_appcompat_version = '1.3.0-beta01'   // 1.3.0-beta01
+
+       compose_version = '1.0.0-beta05'//1.0.0-beta03 <---> kotlin 1.4.31 / 1.0.0-beta04 <---> kotlin 1.4.32 <-->1.0.0-beta05
+       compose_constraintlayout_version = '1.0.0-alpha05'
+       compose_navigation_version = '1.0.0-alpha10'//1.0.0-alpha10
+       compose_lifecycle_version = '1.0.0-alpha04'//1.0.0-alpha04
+       compose_accompanist = "0.8.0"
    }
 
     repositories {
@@ -57,7 +65,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.0-alpha08'
+        classpath "com.android.tools.build:gradle:${android_gradle_plugin_version}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
 
 buildscript {
    ext{
-       kotlin_version = '1.4.30'
+       kotlin_version = '1.4.32'
 
        coroutines_version = '1.4.2'
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,35 @@ buildscript {
    }
 
     repositories {
+        mavenCentral()
+        mavenLocal()
         google()
+        maven { url 'https://www.jitpack.io' }
+        //JB_Kotlin_Multiplatform
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+
+        //JB_Compose
+        maven {
+            url = "https://maven.pkg.jetbrains.space/public/p/compose/dev"
+        }
+        maven {
+            url = "https://oss.sonatype.org/content/repositories/snapshots"
+        }
+        maven {
+            url = "https://androidx.dev/snapshots/builds/artifacts/repository/"
+        }
+
+        gradlePluginPortal()
+        maven { url 'https://dl.bintray.com/bashor/test' }
+        maven { url 'https://dl.bintray.com/kotlin/kotlin-dev' }
+        maven {
+            url = "https://dl.bintray.com/kotlin/kotlin-eap"
+        }
+        maven {
+            url = 'file://' + new File(System.getProperty('user.home'), '.m2/repository').absolutePath
+        }
         jcenter()
     }
 
@@ -40,7 +68,36 @@ plugins {
 
 subprojects {
     repositories {
+        mavenCentral()
+        mavenLocal()
         google()
+        maven { url 'https://www.jitpack.io' }
+        //JB_Kotlin_Multiplatform
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+
+        //JB_Compose
+        maven {
+            url = "https://maven.pkg.jetbrains.space/public/p/compose/dev"
+        }
+        maven {
+            url = "https://oss.sonatype.org/content/repositories/snapshots"
+        }
+        maven {
+            url = "https://androidx.dev/snapshots/builds/artifacts/repository/"
+        }
+
+
+        gradlePluginPortal()
+        maven { url 'https://dl.bintray.com/bashor/test' }
+        maven { url 'https://dl.bintray.com/kotlin/kotlin-dev' }
+        maven {
+            url = "https://dl.bintray.com/kotlin/kotlin-eap"
+        }
+        maven {
+            url = 'file://' + new File(System.getProperty('user.home'), '.m2/repository').absolutePath
+        }
         jcenter()
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,13 @@
  */
 
 buildscript {
-    ext.kotlin_version = '1.4.30'
-    ext.compose_version = '1.0.0-beta01'
-    ext.coroutines_version = '1.4.2'
+   ext{
+       kotlin_version = '1.4.30'
+
+       coroutines_version = '1.4.2'
+
+       compose_version = '1.0.0-beta01'
+   }
 
     repositories {
         google()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 #Wed Feb 24 18:05:51 CET 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
+#distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Dear Sir

i fork your project to learn compose 

i try downgrade android tools build version to support compose 

Ref : https://marcellogalhardo.dev/posts/2021/03/30/using-compose-beta-on-as-4-1/

and i try  upgrade  compose library version  to 1.0.0-beta05

but compose something different !!??

i get build error

e: org.jetbrains.kotlin.codegen.CompilationException: Back-end (JVM) Internal error: Couldn't inline method call '<get-current>' into
@androidx.compose.runtime.Composable public fun VerticalDigits(focusedDigit: kotlin.Int): kotlin.Unit defined in com.example.androiddevchallenge in file MainActivity.kt

The root cause java.lang.IllegalStateException was thrown at: org.jetbrains.kotlin.codegen.inline.InlineCodegen$Companion.getCompiledMethodNodeInner(InlineCodegen.kt:596)

the reason is

the class --   MainActivity.kt 

at  70 line  https://github.com/alexsullivan114/FinalCountdown/blob/c853aef5dc182435ed5968c81dd4e38064440a19/app/src/main/java/com/example/androiddevchallenge/MainActivity.kt#L70

error 

can help  fix it ?

THX




